### PR TITLE
Build reflection dictionary

### DIFF
--- a/BuildFile.xml
+++ b/BuildFile.xml
@@ -1,7 +1,0 @@
-<use name="ROOTVecOps"/>
-<use name="CondFormats/JetMETObjects"/>
-<use name="JetMETCorrections/Modules"/>
-<use name="CommonTools/Utils"/>
-<export>
-  <lib name="1"/>
-</export>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ target_include_directories(CMSJMECalculators PUBLIC $<BUILD_INTERFACE:${CMAKE_CU
 target_link_libraries(CMSJMECalculators ROOT::Hist ROOT::ROOTVecOps ROOT::Physics)
 install(TARGETS CMSJMECalculators EXPORT CMSJMECalculators-targets LIBRARY DESTINATION ${PKG_LIB_INSTALL})
 
-if(NOT SKBUILD) # also build the dictionary
+if(NOT SKBUILD) # also build the dictionary and install python modules
   set_directory_properties(PROPERTIES INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}/interface;${CMAKE_CURRENT_BINARY_DIR}/CMSJet/include;${CMAKE_CURRENT_BINARY_DIR}/CMSJet/src")
   REFLEX_GENERATE_DICTIONARY(G__CMSJMECalculators ${CMAKE_CURRENT_SOURCE_DIR}/src/classes.h
     SELECTION ${CMAKE_CURRENT_SOURCE_DIR}/src/classes_def.xml
@@ -45,6 +45,11 @@ if(NOT SKBUILD) # also build the dictionary
   add_library(CMSJMECalculatorsDict SHARED G__CMSJMECalculators.cxx)
   target_link_libraries(CMSJMECalculatorsDict CMSJMECalculators)
   install(TARGETS CMSJMECalculatorsDict EXPORT CMSJMECalculators-targets LIBRARY DESTINATION ${PKG_LIB_INSTALL})
+
+  find_package(Python)
+  if(PYTHON_FOUND)
+    install(DIRECTORY "python/CMSJMECalculators" DESTINATION "${PKG_LIB_INSTALL}/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages")
+  endif()
 endif()
 
 install(EXPORT CMSJMECalculators-targets FILE CMSJMECalculators-targets.cmake DESTINATION ${PKG_CMK_INSTALL})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,17 @@ target_include_directories(CMSJMECalculators PUBLIC $<BUILD_INTERFACE:${CMAKE_CU
 target_link_libraries(CMSJMECalculators ROOT::Hist ROOT::ROOTVecOps ROOT::Physics)
 install(TARGETS CMSJMECalculators EXPORT CMSJMECalculators-targets LIBRARY DESTINATION ${PKG_LIB_INSTALL})
 
+if(NOT SKBUILD) # also build the dictionary
+  set_directory_properties(PROPERTIES INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}/interface;${CMAKE_CURRENT_BINARY_DIR}/CMSJet/include;${CMAKE_CURRENT_BINARY_DIR}/CMSJet/src")
+  REFLEX_GENERATE_DICTIONARY(G__CMSJMECalculators ${CMAKE_CURRENT_SOURCE_DIR}/src/classes.h
+    SELECTION ${CMAKE_CURRENT_SOURCE_DIR}/src/classes_def.xml
+    DEPENDS CMSJMECalculators
+    )
+  add_library(CMSJMECalculatorsDict SHARED G__CMSJMECalculators.cxx)
+  target_link_libraries(CMSJMECalculatorsDict CMSJMECalculators)
+  install(TARGETS CMSJMECalculatorsDict EXPORT CMSJMECalculators-targets LIBRARY DESTINATION ${PKG_LIB_INSTALL})
+endif()
+
 install(EXPORT CMSJMECalculators-targets FILE CMSJMECalculators-targets.cmake DESTINATION ${PKG_CMK_INSTALL})
 include(CMakePackageConfigHelpers)
 configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in

--- a/README.md
+++ b/README.md
@@ -34,10 +34,8 @@ cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=<your-prefix> [other-opt
 make
 make install
 ```
-Please note that this will only install the C++ components, not the python
-helpers (yet).
-
-TODO add python installation there
+This will also install the python modules in
+`<your-prefix>/lib/pythonX.Y/site-packages/CMSJMECalculators/`.
 
 Building with scram inside CMSSW is also straightforward:
 ```bash
@@ -48,13 +46,13 @@ scram b
 
 ## Usage
 
-When installed as a python package, the necessary components can be loaded
-with:
+When installed as a python package or directly with CMake,
+the necessary components can be loaded with:
 ```python
 from CMSJMECalculators import loadJMESystematicsCalculators
 loadJMESystematicsCalculators()
 ```
-Note that this will load the shared library and headers in
+Note that this will load the shared library and headers or dictionary in
 [cling](https://root.cern/cling/), the [ROOT](https://root.cern/) interpreter,
 so they can from then on also be used in JITted code, e.g. from
 [RDataFrame](https://root.cern/doc/master/classROOT_1_1RDataFrame.html).

--- a/README.md
+++ b/README.md
@@ -23,12 +23,19 @@ pip install git+https://github.com/pieterdavid/CMSJMECalculators.git
 [scikit-build](https://scikit-build.readthedocs.io/en/latest/) is used to
 compile the C++ components against the available ROOT distribution.
 
-From C++ there are two options: [CMake](https://cmake.org/) and (inside
-CMSSW)
-[scram](https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideScram).
+Inside a CMSSW environment, the [`install_cmssw.sh`](install_cmssw.sh) script
+can be used:
+```bash
+wget -q https://raw.githubusercontent.com/pieterdavid/CMSJMECalculators/main/install_cmssw.sh
+source ./install_cmssw.sh
+```
+if a specific version is needed, the `$VERSION` variable can be set, e.g.
+```bash
+VERSION=0.1.0 source ./install_cmssw.sh
+```
 
-A standalone CMake build can be done using the standard commands
-(after cloning the repository):
+From C++ the package can be installed directly with [CMake](https://cmake.org/),
+using the standard commands (after cloning the repository):
 ```bash
 cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=<your-prefix> [other-options] <source-clone>
 make
@@ -36,13 +43,6 @@ make install
 ```
 This will also install the python modules in
 `<your-prefix>/lib/pythonX.Y/site-packages/CMSJMECalculators/`.
-
-Building with scram inside CMSSW is also straightforward:
-```bash
-cd $CMSSW_BASE/src
-git clone -o upstream https://github.com/pieterdavid/CMSJMECalculators.git UserCode/CMSJMECalculators
-scram b
-```
 
 ## Usage
 
@@ -56,11 +56,6 @@ Note that this will load the shared library and headers or dictionary in
 [cling](https://root.cern/cling/), the [ROOT](https://root.cern/) interpreter,
 so they can from then on also be used in JITted code, e.g. from
 [RDataFrame](https://root.cern/doc/master/classROOT_1_1RDataFrame.html).
-
-When installed inside a CMSSW environment, the import should be modified to
-```python
-from UserCode.CMSJMECalculators.CMSJMECalculators import loadJMESystematicsCalculators
-```
 
 The variations are calculated by the C++ classes ``JetVariationsCalculator`` and
 ``FatJetVariationsCalculator`` for the AK4 and AK8 jet JER and JES variations, and

--- a/install_cmssw.sh
+++ b/install_cmssw.sh
@@ -56,7 +56,7 @@ echo "--> Installing as ${toolname} with python=${PYTHON} (${pymajmin}) into ${i
 
 origin="git+https://github.com/pieterdavid/CMSJMECalculators.git"
 if [ "${VERSION}" ]; then
-  origin="${origin}@${version}"
+  origin="${origin}@${VERSION}"
 fi
 
 # First, download and install pip, if needed

--- a/install_cmssw.sh
+++ b/install_cmssw.sh
@@ -1,0 +1,114 @@
+# no shebang, must be sourced
+
+# Check if in CMSSW
+if [ -z "$CMSSW_BASE" ]; then
+  echo "You must use this package inside a CMSSW environment"
+  return 1
+fi
+
+## deduce source location from the script name
+if [[ -z "${ZSH_NAME}" ]]; then
+  thisscript="$(readlink -f ${BASH_SOURCE})"
+else
+  thisscript="$(readlink -f ${0})"
+fi
+pipinstall="$(dirname ${thisscript})/.python"
+
+local pyvers=""
+if [ ! "${PYTHON}" ]; then
+  # check if this is a python2 or python3 release
+  which python2 > /dev/null 2> /dev/null
+  if [ $? -ne 0 ]; then
+    PYTHON=python
+    pyvers=py2
+  else
+    python2 -c 'import FWCore.ParameterSet as cms' > /dev/null 2> /dev/null
+    if [ $? -ne 0 ]; then 
+      PYTHON=python3
+      pyvers=py3
+    else
+      PYTHON=python2
+      pyvers=py2
+    fi
+  fi
+else
+  pyvers="py$(${PYTHON} -c 'import sys; print(sys.version_info[0])')"
+fi
+
+toolname="${pyvers}-cmsjmecalculators"
+
+# Check if it is already installed
+scram tool info "${toolname}" > /dev/null 2> /dev/null
+if [ $? -eq 0 ]; then
+  echo "--> ${toolname} already installed"
+  return 0
+fi
+
+installpath="${CMSSW_BASE}/install/${toolname}"
+if [ -d "${installpath}" ]; then
+  echo "--> Install path ${installpath} exists, please remove and try again if you want to reinstall"
+  return 1
+fi
+
+pymajmin=$(${PYTHON} -c 'import sys; print(".".join(str(num) for num in sys.version_info[:2]))')
+
+echo "--> Installing as ${toolname} with python=${PYTHON} (${pymajmin}) into ${installpath}"
+
+origin="git+https://github.com/pieterdavid/CMSJMECalculators.git"
+if [ "${VERSION}" ]; then
+  origin="${origin}@${version}"
+fi
+
+# First, download and install pip, if needed
+local bk_pythonpath="${PYTHONPATH}"
+local bk_path="${PATH}"
+local bk_tmpdir="${TMPDIR}"
+TMPDIR="${CMSSW_BASE}/tmp"
+( ${PYTHON} -m pip --version && ${PYTHON} -m pip download -v "${origin}" ) > /dev/null 2> /dev/null
+if [ $? -ne 0 ]; then
+  echo "--> No working pip found, bootstrapping in ${pipinstall}"
+  [ -d "${pipinstall}" ] || mkdir "${pipinstall}"
+  if [ ! -f "${pipinstall}/bin/pip" ]; then
+    wget -q -O "${pipinstall}/get-pip.py" "https://bootstrap.pypa.io/pip/${pymajmin}/get-pip.py"
+    ${PYTHON} "${pipinstall}/get-pip.py" --prefix="${pipinstall}" --ignore-installed
+  fi
+  PYTHONPATH="${pipinstall}/lib/python${pymajmin}/site-packages:${PYTHONPATH}"
+  PATH="${pipinstall}/bin:${PATH}"
+  ${PYTHON} -m pip install --prefix="${pipinstall}" --ignore-installed setuptools_scm scikit-build 'cmake>=3.11'
+fi
+
+echo "--> Installing CMSJMECalculators from ${origin}"
+mkdir -p ${installpath}
+${PYTHON} -m pip install --prefix="${installpath}" --ignore-installed "${origin}"
+toolversion=$(${PYTHON} -m pip show "${origin}" | grep Version | sed 's/Version: //')
+
+if [ -d "${pipinstall}" ]; then
+  rm -rf "${pipinstall}"
+fi
+PYTHONPATH="${bk_pythonpath}"
+PATH="${bk_path}"
+TMPDIR="${bk_tmpdir}"
+
+pyversu=$(echo "${pyvers}" | tr 'a-z' 'A-Z')
+pypathname="PYTHONPATH"
+if [[ "${pyvers}" == "py3" ]]; then
+  pypathname="PYTHON3PATH"
+fi
+toolfile="${installpath}/${toolname}.xml"
+cat <<EOF_TOOLFILE >"${toolfile}"
+<tool name="${toolname}" version="${toolversion}">
+  <info url="https://github.com/pieterdavid/CMSJMECalculators"/>
+  <client>
+    <environment name="${pyversu}_CMSJMECALCULATORS_BASE" default="${installpath}"/>
+    <runtime name="LD_LIBRARY_PATH" value="\$${pyversu}_CMSJMECALCULATORS_BASE/lib" type="path"/>
+    <runtime name="${pypathname}"   value="\$${pyversu}_CMSJMECALCULATORS_BASE/lib/python${pymajmin}/site-packages" type="path"/>
+    <runtime name="PATH"            value="\$${pyversu}_CMSJMECALCULATORS_BASE/bin" type="path"/>
+  </client>
+</tool>
+EOF_TOOLFILE
+
+echo "--> Updating environment"
+scram setup "${toolfile}"
+cmsenv
+
+echo "--> ${toolname} is installed."

--- a/interface/JMESystematicsCalculators.h
+++ b/interface/JMESystematicsCalculators.h
@@ -3,19 +3,11 @@
 
 #include <map>
 #include <ROOT/RVec.hxx>
-#if defined(PROJECT_NAME) && defined(CMSSW_GIT_HASH)
-#include "JetMETCorrections/Modules/interface/JetResolution.h"
-#include "CondFormats/JetMETObjects/interface/JetCorrectorParameters.h"
-#include "CondFormats/JetMETObjects/interface/SimpleJetCorrectionUncertainty.h"
-#include "CondFormats/JetMETObjects/interface/FactorizedJetCorrectorCalculator.h"
-#include "CommonTools/Utils/interface/FormulaEvaluator.h"
-#else
 #include "JetResolution.h"
 #include "JetCorrectorParameters.h"
 #include "SimpleJetCorrectionUncertainty.h"
 #include "FactorizedJetCorrectorCalculator.h"
 #include "FormulaEvaluator.h"
-#endif
 
 class TRandom3;
 

--- a/interface/JMESystematicsCalculators.h
+++ b/interface/JMESystematicsCalculators.h
@@ -7,15 +7,16 @@
 #include "JetMETCorrections/Modules/interface/JetResolution.h"
 #include "CondFormats/JetMETObjects/interface/JetCorrectorParameters.h"
 #include "CondFormats/JetMETObjects/interface/SimpleJetCorrectionUncertainty.h"
+#include "CondFormats/JetMETObjects/interface/FactorizedJetCorrectorCalculator.h"
 #include "CommonTools/Utils/interface/FormulaEvaluator.h"
 #else
 #include "JetResolution.h"
 #include "JetCorrectorParameters.h"
 #include "SimpleJetCorrectionUncertainty.h"
+#include "FactorizedJetCorrectorCalculator.h"
 #include "FormulaEvaluator.h"
 #endif
 
-class FactorizedJetCorrectorCalculator;
 class TRandom3;
 
 namespace rdfhelpers {
@@ -170,8 +171,7 @@ protected:
   // parameters and helpers
   JME::JetResolution m_jetPtRes;
   JME::JetResolutionScaleFactor m_jetEResSF;
-  struct jetcorrdeleter { void operator()(FactorizedJetCorrectorCalculator*) const; };
-  std::unique_ptr<FactorizedJetCorrectorCalculator,jetcorrdeleter> m_jetCorrector;
+  std::unique_ptr<FactorizedJetCorrectorCalculator> m_jetCorrector;
   std::unordered_map<std::string,SimpleJetCorrectionUncertainty> m_jesUncSources;
 };
 
@@ -222,7 +222,7 @@ public:
 protected:
   float m_unclEnThreshold = 15.;
   bool m_isT1SmearedMET = false;
-  std::unique_ptr<FactorizedJetCorrectorCalculator,jetcorrdeleter> m_jetCorrectorL1;
+  std::unique_ptr<FactorizedJetCorrectorCalculator> m_jetCorrectorL1;
   void addVariations(Type1METVariationsCalculator::result_t& out,
       const p4compv_t& jet_pt, const p4compv_t& jet_eta, const p4compv_t& jet_phi, const p4compv_t& jet_mass,
       const p4compv_t& jet_rawcorr, const p4compv_t& jet_area, const p4compv_t& jet_muonSubtrFactor,
@@ -259,8 +259,8 @@ public:
       const float t1met_phi, const float t1met_pt    // "METFixEE2017"
       ) const;
 protected:
-  std::unique_ptr<FactorizedJetCorrectorCalculator,jetcorrdeleter> m_jetCorrectorProd;
-  std::unique_ptr<FactorizedJetCorrectorCalculator,jetcorrdeleter> m_jetCorrectorL1Prod;
+  std::unique_ptr<FactorizedJetCorrectorCalculator> m_jetCorrectorProd;
+  std::unique_ptr<FactorizedJetCorrectorCalculator> m_jetCorrectorL1Prod;
   std::array<double,4> calculateFixEE2017Offset(ROOT::VecOps::RVec<bool>& jet_mask,
       const p4compv_t& jet_pt, const p4compv_t& jet_eta, const p4compv_t& jet_phi, const p4compv_t& jet_mass,
       const p4compv_t& jet_rawcorr, const p4compv_t& jet_area, const p4compv_t& jet_muonSubtrFactor,

--- a/python/CMSJMECalculators/load.py
+++ b/python/CMSJMECalculators/load.py
@@ -23,9 +23,9 @@ def loadJMESystematicsCalculators():
             gbl.gInterpreter.AddIncludePath(incDir)
             gbl.gROOT.ProcessLine('#include "JMESystematicsCalculators.h"')
         except pkg_resources.DistributionNotFound:  # fallback: load directly
-            # TODO guess path from __file__ and add to dynamic path?
-            libName = "libCMSJMECalculators"
+            libName = "libCMSJMECalculatorsDict"
             import ROOT as gbl
+            gbl.gSystem.AddDynamicPath(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__)))))
             st = gbl.gSystem.Load(libName)
             if st == -1:
                 raise RuntimeError("Library {0} could not be found".format(libName))

--- a/python/CMSJMECalculators/load.py
+++ b/python/CMSJMECalculators/load.py
@@ -6,20 +6,29 @@ def loadJMESystematicsCalculators():
         gbl.gROOT.ProcessLine('#define PROJECT_NAME "CMSSW"')
         gbl.gROOT.ProcessLine('#define CMSSW_GIT_HASH {}'.format(os.environ["CMSSW_GIT_HASH"]))
         gbl.gROOT.ProcessLine('#include "UserCode/CMSJMECalculators/interface/JMESystematicsCalculators.h"')
-        getattr(gbl, "JetVariationsCalculator::result_t")  # trigger dictionary generation
-    else:  # pip version
+    else:
         import pkg_resources
-        incDir = pkg_resources.resource_filename("CMSJMECalculators", "include")
-        libDir = pkg_resources.resource_filename("CMSJMECalculators", "lib")
-        libName = "libCMSJMECalculators"
-        import os.path
-        import ROOT as gbl
-        st = gbl.gSystem.Load(os.path.join(libDir, libName))
-        if st == -1:
-            raise RuntimeError("Library {0} could not be found".format(libName))
-        elif st == -2:
-            raise RuntimeError("Version match for library {0}".format(libName))
-        gbl.gInterpreter.AddIncludePath(incDir)
-        gbl.gROOT.ProcessLine('#include "JMESystematicsCalculators.h"')
-        getattr(gbl, "JetVariationsCalculator::result_t")  # trigger dictionary generation
-
+        try:  # pip version
+            dist_info = pkg_resources.get_distribution("CMSJMECalculators")
+            incDir = pkg_resources.resource_filename("CMSJMECalculators", "include")
+            libDir = pkg_resources.resource_filename("CMSJMECalculators", "lib")
+            libName = "libCMSJMECalculators"
+            import os.path
+            import ROOT as gbl
+            st = gbl.gSystem.Load(os.path.join(libDir, libName))
+            if st == -1:
+                raise RuntimeError("Library {0} could not be found".format(libName))
+            elif st == -2:
+                raise RuntimeError("Version match for library {0}".format(libName))
+            gbl.gInterpreter.AddIncludePath(incDir)
+            gbl.gROOT.ProcessLine('#include "JMESystematicsCalculators.h"')
+        except pkg_resources.DistributionNotFound:  # fallback: load directly
+            # TODO guess path from __file__ and add to dynamic path?
+            libName = "libCMSJMECalculators"
+            import ROOT as gbl
+            st = gbl.gSystem.Load(libName)
+            if st == -1:
+                raise RuntimeError("Library {0} could not be found".format(libName))
+            elif st == -2:
+                raise RuntimeError("Version match for library {0}".format(libName))
+    getattr(gbl, "JetVariationsCalculator::result_t")  # trigger dictionary generation

--- a/python/CMSJMECalculators/load.py
+++ b/python/CMSJMECalculators/load.py
@@ -1,34 +1,32 @@
 def loadJMESystematicsCalculators():
     import os
-    if "CMSSW_BASE" in os.environ:  # CMSSW/scram version
-        import ROOT as gbl
-        gbl.gSystem.Load("libUserCodeCMSJMECalculators")
-        gbl.gROOT.ProcessLine('#define PROJECT_NAME "CMSSW"')
-        gbl.gROOT.ProcessLine('#define CMSSW_GIT_HASH {}'.format(os.environ["CMSSW_GIT_HASH"]))
-        gbl.gROOT.ProcessLine('#include "UserCode/CMSJMECalculators/interface/JMESystematicsCalculators.h"')
-    else:
-        import pkg_resources
-        try:  # pip version
-            dist_info = pkg_resources.get_distribution("CMSJMECalculators")
-            incDir = pkg_resources.resource_filename("CMSJMECalculators", "include")
-            libDir = pkg_resources.resource_filename("CMSJMECalculators", "lib")
-            libName = "libCMSJMECalculators"
-            import os.path
-            import ROOT as gbl
-            st = gbl.gSystem.Load(os.path.join(libDir, libName))
-            if st == -1:
-                raise RuntimeError("Library {0} could not be found".format(libName))
-            elif st == -2:
-                raise RuntimeError("Version match for library {0}".format(libName))
-            gbl.gInterpreter.AddIncludePath(incDir)
-            gbl.gROOT.ProcessLine('#include "JMESystematicsCalculators.h"')
-        except pkg_resources.DistributionNotFound:  # fallback: load directly
+    import pkg_resources
+    import ROOT as gbl
+    try:  # pip version
+        pkg_resources.get_distribution("CMSJMECalculators")
+        incDir = pkg_resources.resource_filename("CMSJMECalculators", "include")
+        libDir = pkg_resources.resource_filename("CMSJMECalculators", "lib")
+        libName = "libCMSJMECalculators"
+        import os.path
+        st = gbl.gSystem.Load(os.path.join(libDir, libName))
+        if st == -1:
+            raise RuntimeError("Library {0} could not be found".format(libName))
+        elif st == -2:
+            raise RuntimeError("Version match for library {0}".format(libName))
+        gbl.gInterpreter.AddIncludePath(incDir)
+        gbl.gROOT.ProcessLine('#include "JMESystematicsCalculators.h"')
+    except pkg_resources.DistributionNotFound as ex:
+        if "CMSSW_BASE" in os.environ:  # CMSSW/scram version
+            gbl.gSystem.Load("libUserCodeCMSJMECalculators")
+            gbl.gROOT.ProcessLine('#define PROJECT_NAME "CMSSW"')
+            gbl.gROOT.ProcessLine('#define CMSSW_GIT_HASH {}'.format(os.environ["CMSSW_GIT_HASH"]))
+            gbl.gROOT.ProcessLine('#include "UserCode/CMSJMECalculators/interface/JMESystematicsCalculators.h"')
+        else:  # fallback: load directly
             libName = "libCMSJMECalculatorsDict"
-            import ROOT as gbl
             gbl.gSystem.AddDynamicPath(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__)))))
             st = gbl.gSystem.Load(libName)
             if st == -1:
                 raise RuntimeError("Library {0} could not be found".format(libName))
             elif st == -2:
                 raise RuntimeError("Version match for library {0}".format(libName))
-    getattr(gbl, "JetVariationsCalculator::result_t")  # trigger dictionary generation
+    getattr(gbl, "JetVariationsCalculator::result_t")  # trigger dictionary generation (if needed)

--- a/python/CMSJMECalculators/load.py
+++ b/python/CMSJMECalculators/load.py
@@ -15,18 +15,12 @@ def loadJMESystematicsCalculators():
             raise RuntimeError("Version match for library {0}".format(libName))
         gbl.gInterpreter.AddIncludePath(incDir)
         gbl.gROOT.ProcessLine('#include "JMESystematicsCalculators.h"')
-    except pkg_resources.DistributionNotFound as ex:
-        if "CMSSW_BASE" in os.environ:  # CMSSW/scram version
-            gbl.gSystem.Load("libUserCodeCMSJMECalculators")
-            gbl.gROOT.ProcessLine('#define PROJECT_NAME "CMSSW"')
-            gbl.gROOT.ProcessLine('#define CMSSW_GIT_HASH {}'.format(os.environ["CMSSW_GIT_HASH"]))
-            gbl.gROOT.ProcessLine('#include "UserCode/CMSJMECalculators/interface/JMESystematicsCalculators.h"')
-        else:  # fallback: load directly
-            libName = "libCMSJMECalculatorsDict"
-            gbl.gSystem.AddDynamicPath(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__)))))
-            st = gbl.gSystem.Load(libName)
-            if st == -1:
-                raise RuntimeError("Library {0} could not be found".format(libName))
-            elif st == -2:
-                raise RuntimeError("Version match for library {0}".format(libName))
+    except pkg_resources.DistributionNotFound as ex:  # fallback: load directly
+        libName = "libCMSJMECalculatorsDict"
+        gbl.gSystem.AddDynamicPath(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__)))))
+        st = gbl.gSystem.Load(libName)
+        if st == -1:
+            raise RuntimeError("Library {0} could not be found".format(libName))
+        elif st == -2:
+            raise RuntimeError("Version match for library {0}".format(libName))
     getattr(gbl, "JetVariationsCalculator::result_t")  # trigger dictionary generation (if needed)

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,19 @@
+import os, os.path
 from setuptools import find_packages
 from setuptools_scm import get_version
 from skbuild import setup
+
+cmake_args = [
+        f"-DCMSJMECALCULATOR_VERSION:STRING={get_version()}",
+        ]
+if os.getenv("CMSSW_BASE") and os.getenv("ROOTSYS"):
+    rootdir= os.path.join(os.getenv("ROOTSYS"), "cmake")
+    if os.path.isdir(rootdir):
+        cmake_args.append(f"-DROOT_DIR={rootdir}")
 
 setup(
     packages=find_packages(where="python"),
     package_dir={"": "python"},
     cmake_install_dir="python",
-    cmake_args=[f"-DCMSJMECALCULATOR_VERSION:STRING={get_version()}"],
+    cmake_args=cmake_args
 )

--- a/src/JMESystematicsCalculators.cc
+++ b/src/JMESystematicsCalculators.cc
@@ -28,12 +28,9 @@ JetMETVariationsCalculatorBase::~JetMETVariationsCalculatorBase()
 void JetMETVariationsCalculatorBase::setJEC(const std::vector<JetCorrectorParameters>& jecParams)
 {
   if ( ! jecParams.empty() ) {
-    m_jetCorrector = std::unique_ptr<FactorizedJetCorrectorCalculator,jetcorrdeleter>{new FactorizedJetCorrectorCalculator(jecParams)};
+    m_jetCorrector = std::unique_ptr<FactorizedJetCorrectorCalculator>{new FactorizedJetCorrectorCalculator(jecParams)};
   }
 }
-
-void JetMETVariationsCalculatorBase::jetcorrdeleter::operator() (FactorizedJetCorrectorCalculator* ptr) const
-{ delete ptr; }
 
 namespace {
   TRandom3& getTRandom3(uint32_t seed) {
@@ -665,7 +662,7 @@ std::vector<std::string> FatJetVariationsCalculator::available(const std::string
 void Type1METVariationsCalculator::setL1JEC(const std::vector<JetCorrectorParameters>& jecParams)
 {
   if ( ! jecParams.empty() ) {
-    m_jetCorrectorL1 = std::unique_ptr<FactorizedJetCorrectorCalculator,jetcorrdeleter>{new FactorizedJetCorrectorCalculator(jecParams)};
+    m_jetCorrectorL1 = std::unique_ptr<FactorizedJetCorrectorCalculator>{new FactorizedJetCorrectorCalculator(jecParams)};
   }
 }
 
@@ -867,13 +864,13 @@ std::vector<std::string> Type1METVariationsCalculator::available(const std::stri
 void FixEE2017Type1METVariationsCalculator::setJECProd(const std::vector<JetCorrectorParameters>& jecParams)
 {
   if ( ! jecParams.empty() ) {
-    m_jetCorrectorProd = std::unique_ptr<FactorizedJetCorrectorCalculator,jetcorrdeleter>{new FactorizedJetCorrectorCalculator(jecParams)};
+    m_jetCorrectorProd = std::unique_ptr<FactorizedJetCorrectorCalculator>{new FactorizedJetCorrectorCalculator(jecParams)};
   }
 }
 void FixEE2017Type1METVariationsCalculator::setL1JECProd(const std::vector<JetCorrectorParameters>& jecParams)
 {
   if ( ! jecParams.empty() ) {
-    m_jetCorrectorL1Prod = std::unique_ptr<FactorizedJetCorrectorCalculator,jetcorrdeleter>{new FactorizedJetCorrectorCalculator(jecParams)};
+    m_jetCorrectorL1Prod = std::unique_ptr<FactorizedJetCorrectorCalculator>{new FactorizedJetCorrectorCalculator(jecParams)};
   }
 }
 

--- a/src/JMESystematicsCalculators.cc
+++ b/src/JMESystematicsCalculators.cc
@@ -1,10 +1,5 @@
-#if defined(PROJECT_NAME) && defined(CMSSW_GIT_HASH)
-#include "UserCode/CMSJMECalculators/interface/JMESystematicsCalculators.h"
-#include "CondFormats/JetMETObjects/interface/FactorizedJetCorrectorCalculator.h"
-#else
 #include "JMESystematicsCalculators.h"
 #include "FactorizedJetCorrectorCalculator.h"
-#endif
 
 #include <Math/GenVector/LorentzVector.h>
 #include <Math/GenVector/PtEtaPhiM4D.h>

--- a/src/classes.h
+++ b/src/classes.h
@@ -1,5 +1,1 @@
-#if defined(PROJECT_NAME) && defined(CMSSW_GIT_HASH)
-#include "UserCode/CMSJMECalculators/interface/JMESystematicsCalculators.h"
-#else
 #include "JMESystematicsCalculators.h"
-#endif

--- a/src/classes.h
+++ b/src/classes.h
@@ -1,0 +1,5 @@
+#if defined(PROJECT_NAME) && defined(CMSSW_GIT_HASH)
+#include "UserCode/CMSJMECalculators/interface/JMESystematicsCalculators.h"
+#else
+#include "JMESystematicsCalculators.h"
+#endif

--- a/src/classes_def.xml
+++ b/src/classes_def.xml
@@ -1,0 +1,7 @@
+<lcgdict>
+  <class name="FatJetVariationsCalculator" persistent="false" />
+  <class name="FixEE2017Type1METVariationsCalculator" persistent="false" />
+  <class name="JetMETVariationsCalculatorBase" persistent="false" />
+  <class name="JetVariationsCalculator" persistent="false" />
+  <class name="Type1METVariationsCalculator" persistent="false" />
+</lcgdict>


### PR DESCRIPTION
This should build the reflection dictionary, such that it does not need to be constructed from the headers, e.g.
```python
from cppyy import gbl
gbl.gSystem.AddDynamicPath("../test-install/lib")
gbl.gSystem.Load("libCMSJMECalculatorsDict.so")
calc = gbl.Type1METVariationsCalculator()
```
I enabled it only for cmake builds outside scikit-build for now

CC @sroychow